### PR TITLE
Fix order service status handling and add tests

### DIFF
--- a/internet-provider-order-system/app/services/order_service.py
+++ b/internet-provider-order-system/app/services/order_service.py
@@ -3,6 +3,7 @@ from app.models import Order, OrderItem, Product, Customer
 from app.services.pricing_service import PricingService
 from datetime import datetime
 import uuid
+import json
 
 class OrderService:
     def __init__(self):
@@ -25,8 +26,8 @@ class OrderService:
         order = Order(
             order_number=order_number,
             customer_id=data['customer_id'],
-            created_by=data['created_by'],
-            status='pending',
+            created_by_id=data['created_by'],
+            order_status='pending',
             total_amount=0,
             promotional_code=data.get('promotional_code'),
             negotiated_price=data.get('negotiated_price', 0)
@@ -54,7 +55,7 @@ class OrderService:
                     product_id=product.id,
                     quantity=quantity,
                     unit_price=unit_price,
-                    configuration=item_data.get('configuration', {})
+                    configuration=json.dumps(item_data.get('configuration', {}))
                 )
                 
                 db.session.add(order_item)
@@ -75,7 +76,7 @@ class OrderService:
         """Update order status"""
         order = self.get_order_by_id(order_id)
         if order:
-            order.status = status
+            order.order_status = status
             order.updated_at = datetime.now()
             db.session.commit()
         return order
@@ -110,7 +111,7 @@ class OrderService:
     
     def get_orders_by_status(self, status):
         """Get orders by status"""
-        return Order.query.filter_by(status=status).order_by(Order.created_at.desc()).all()
+        return Order.query.filter_by(order_status=status).order_by(Order.created_at.desc()).all()
     
     def get_recent_orders(self, limit=10):
         """Get recent orders"""

--- a/internet-provider-order-system/tests/test_order_service.py
+++ b/internet-provider-order-system/tests/test_order_service.py
@@ -1,0 +1,48 @@
+import os
+import json
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app, db
+from app.models import User, Customer, Product, ProductCategory, Order
+from app.services.order_service import OrderService
+
+
+def setup_app():
+    os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+    app = create_app()
+    app.testing = True
+    return app
+
+
+def test_create_and_update_order_status():
+    app = setup_app()
+    with app.app_context():
+        user = User(username='agent', email='agent@example.com')
+        user.set_password('password')
+        customer = Customer(first_name='John', last_name='Doe', email='john@example.com')
+        category = ProductCategory(name='Internet')
+        product = Product(name='Basic Plan', base_price=50.0, category=category)
+        db.session.add_all([user, customer, category, product])
+        db.session.commit()
+
+        service = OrderService()
+        order_data = {
+            'customer_id': customer.id,
+            'created_by': user.id,
+            'items': [
+                {'product_id': product.id, 'quantity': 1}
+            ]
+        }
+
+        order = service.create_order(order_data)
+        assert order.order_status == 'pending'
+        assert order.created_by_id == user.id
+
+        service.update_order_status(order.id, 'confirmed')
+        updated = service.get_order_by_id(order.id)
+        assert updated.order_status == 'confirmed'
+
+        confirmed_orders = service.get_orders_by_status('confirmed')
+        assert order.id in [o.id for o in confirmed_orders]


### PR DESCRIPTION
## Summary
- Correct order creation and status updates to use proper field names
- Store item configuration as JSON and add test coverage for order status workflow

## Testing
- `pytest tests/test_order_service.py -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68a69aee14308323a41c8794c3ca1820